### PR TITLE
print-ctf: Improve formatting and control depth

### DIFF
--- a/durin/src/lib.rs
+++ b/durin/src/lib.rs
@@ -219,6 +219,29 @@ pub enum TypeKind {
     Restrict = 13,
 }
 
+impl fmt::Display for TypeKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = match self {
+            Self::Unknown => "unknown",
+            Self::Integer => "int",
+            Self::Float => "float",
+            Self::Pointer => "pointer",
+            Self::Array => "array",
+            Self::Function => "fn",
+            Self::Struct => "struct",
+            Self::Union => "union",
+            Self::Enum => "enum",
+            Self::Forward => "forward",
+            Self::Typedef => "typedef",
+            Self::Volatile => "volatile",
+            Self::Const => "const",
+            Self::Restrict => "restrict",
+        };
+
+        write!(f, "{desc}")
+    }
+}
+
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Default, Debug)]
 pub struct IntegerEncoding {
     pub bits: u16,
@@ -328,4 +351,3 @@ mod testhelper {
         encoding.flags = IntegerFlags(0xff);
     }
 }
-

--- a/print-ctf/src/main.rs
+++ b/print-ctf/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use clap::Parser;
-use durin::read::CtfReader;
+use durin::read::{CtfMemberIter, CtfReader, CtfType};
 
 use std::fs;
 use std::io::{self, Write};
@@ -14,6 +14,11 @@ struct Cli {
     /// The names of the types to print.
     #[clap(long = "type", short, value_name = "TYPE")]
     types: Vec<String>,
+
+    /// The maximum depth for expanding nested types. A depth of 0 prints the
+    /// top-level type without expanding members.
+    #[clap(short = 'd', long, default_value_t = 3)]
+    max_depth: usize,
 }
 
 fn main() {
@@ -39,6 +44,8 @@ fn exec(args: &Cli) -> Result<()> {
 
     let mut out = io::stdout().lock();
 
+    let depth = 0;
+
     for name in &args.types {
         let iter = ctf.find_all(name);
 
@@ -48,9 +55,142 @@ fn exec(args: &Cli) -> Result<()> {
         };
 
         for ctf_ty in iter {
-            writeln!(out, "{ctf_ty:#?}")?;
+            writeln!(out, "{}", format_type(&ctf_ty, depth, args.max_depth))?;
         }
     }
 
     Ok(())
+}
+
+fn format_type(ty: &CtfType, depth: usize, max_depth: usize) -> String {
+    if depth > max_depth {
+        return String::new();
+    }
+
+    let mut desc = ty_title(ty);
+
+    match ty {
+        CtfType::Unknown(_u) => {
+            // No further formatting.
+        }
+        CtfType::Integer(i) => {
+            desc.push_str(&format!(", size {}, encoding {:?}", i.size(), i.encoding()));
+        }
+        CtfType::Float(f) => {
+            desc.push_str(&format!(", size {}, encoding {:?}", f.size(), f.encoding()));
+        }
+        CtfType::Pointer(p) => {
+            desc.push_str(&format!(", target {}", ty_title(&p.target())));
+        }
+        CtfType::Array(a) => {
+            desc.push_str(&format!(
+                ", element type {}, len {}",
+                a.element_type().name(),
+                a.len()
+            ));
+        }
+        CtfType::Function(f) => {
+            desc.push_str(&format!(
+                ", return type {}, is_varargs: {}",
+                ty_title(&f.return_type()),
+                f.is_varargs(),
+            ));
+            if f.arg_count() > 0 {
+                desc.push_str(", args:");
+            }
+            for arg in f.args() {
+                desc.push_str(&format!(
+                    "\n <{}> {} {}",
+                    arg.id().get(),
+                    arg.kind(),
+                    arg.name(),
+                ));
+            }
+            todo!()
+        }
+        CtfType::Struct(s) => {
+            desc.push_str(&format!(", size: {}", s.size()));
+            if depth < max_depth {
+                if s.members().len() > 0 {
+                    desc.push_str(", members:");
+                }
+                desc.push_str(&format_members(s.members(), depth + 1, max_depth));
+            }
+        }
+        CtfType::Union(u) => {
+            desc.push_str(&format!(", size: {}", u.size()));
+
+            if depth < max_depth {
+                if u.members().len() > 0 {
+                    desc.push_str(", members:");
+                }
+                desc.push_str(&format_members(u.members(), depth + 1, max_depth));
+            }
+        }
+        CtfType::Enum(e) => {
+            let iter = e.enumerators();
+            if iter.len() > 0 {
+                desc.push_str(", enumerators:");
+            }
+            for enumerator in e.enumerators() {
+                desc.push_str(&format!(
+                    "\n{}{}={}",
+                    "  ".repeat(depth + 1),
+                    enumerator.name(),
+                    enumerator.value()
+                ));
+            }
+        }
+        CtfType::Forward(_f) => {
+            // No further formatting.
+        }
+        CtfType::Typedef(t) => {
+            desc.push_str(&format!(", target {}", ty_title(&t.target())));
+        }
+        CtfType::Volatile(v) => {
+            desc.push_str(&format!(", target {}", ty_title(&v.target())));
+        }
+        CtfType::Const(c) => {
+            desc.push_str(&format!(", target {}", ty_title(&c.target())));
+        }
+        CtfType::Restrict(r) => {
+            desc.push_str(&format!(", target {}", ty_title(&r.target())));
+        }
+    }
+
+    desc
+}
+
+fn format_members(members: CtfMemberIter, depth: usize, max_depth: usize) -> String {
+    let mut desc = String::new();
+    if depth > max_depth {
+        return desc;
+    }
+
+    for member in members {
+        let member_desc = format_type(&member.ty(), depth, max_depth);
+        if member_desc.is_empty() {
+            desc.push_str(&format!(
+                "\n{}{}, offset {}, {}",
+                "  ".repeat(depth),
+                member.name(),
+                member.offset(),
+                ty_title(&member.ty())
+            ));
+        } else {
+            desc.push_str(&format!(
+                "\n{}{}, offset {}, {}",
+                "  ".repeat(depth),
+                member.name(),
+                member.offset(),
+                member_desc,
+            ));
+        }
+    }
+
+    desc
+}
+
+fn ty_title(ty: &CtfType) -> String {
+    format!("<{}> {} {}", ty.id().get(), ty.kind(), ty.name())
 }


### PR DESCRIPTION
The current `print-ctf` output for a deeply nested type like `tokio::runtime::context::Context` is extremely large and hard to follow.

Perform some basic formatting on the types to mostly match `ctfdump(1)`, but with inline nesting of members. Add a CLI flag to control how deeply we should recurse into the members.