### PR TITLE
hansei: Add 'task-trace' subcommand

### DIFF
--- a/durin/src/read/raw_types.rs
+++ b/durin/src/read/raw_types.rs
@@ -46,7 +46,7 @@ impl TryFromCtx<'_, Endian> for CtfHeader {
             return Err(Error::misaligned_object_offset(objtoff));
         }
         let funcoff = from.gread_with(offset, endian)?;
-        if funcoff % 4 != 0 {
+        if funcoff % 2 != 0 {
             return Err(Error::misaligned_func_offset(funcoff));
         }
         let typeoff = from.gread_with(offset, endian)?;

--- a/dwarf2ctf/src/parser.rs
+++ b/dwarf2ctf/src/parser.rs
@@ -1888,8 +1888,12 @@ fn stub_to_ctf_type(
                 }
             }
 
-            // Sort members by offset for consistent CTF output
+            // Sort members by offset for consistent CTF output and
+            // deduplicate.  Rust async-fn environments can produce DWARF
+            // with the same member listed more than once (e.g. two `self`
+            // entries at the same offset).
             ctf_members.sort_by_key(|m| m.offset_bits);
+            ctf_members.dedup_by(|a, b| a.name == b.name && a.offset_bits == b.offset_bits);
 
             Ok(CtfType::Struct {
                 name: name.clone(),
@@ -2087,8 +2091,10 @@ fn build_variant_part_members(
     let mut max_variant_size: u32 = 0;
 
     for variant in &variant_part.variants {
-        // Adjust member offsets to be relative to the union start
-        let adjusted_members: Vec<CtfMember> = variant
+        // Adjust member offsets to be relative to the union start and
+        // deduplicate (rustc can emit the same member twice in async-fn
+        // environment DWARF).
+        let mut adjusted_members: Vec<CtfMember> = variant
             .members
             .iter()
             .map(|m| CtfMember {
@@ -2097,6 +2103,8 @@ fn build_variant_part_members(
                 offset_bits: (m.offset_bytes * 8).saturating_sub(union_offset_bits),
             })
             .collect();
+        adjusted_members.sort_by_key(|m| m.offset_bits);
+        adjusted_members.dedup_by(|a, b| a.name == b.name && a.offset_bits == b.offset_bits);
 
         // Calculate variant struct size
         let variant_size = parent_struct_size.saturating_sub((union_offset_bits / 8) as u32);

--- a/dwarf2ctf/src/parser.rs
+++ b/dwarf2ctf/src/parser.rs
@@ -1406,9 +1406,7 @@ impl<'a, R: Reader<Offset = usize>> DependencyCollector<'a, R> {
                     let is_discr = discr_offset.is_some_and(|off| child.entry().offset() == off);
                     if is_discr {
                         let mut member = self.extract_member_stub(unit, child.entry())?;
-                        if member.name.is_empty() {
-                            member.name = "__discr".to_string();
-                        }
+                        member.name = "__discr".to_string();
                         if let Some(type_ref) = member.type_ref {
                             deps.push(type_ref);
                         }
@@ -2013,6 +2011,13 @@ fn build_variant_part_members(
         // of the variant type references have a `DW_AT_data_member_location` at offset
         // 0, which would overlap with the discriminant if that were present. If there
         // is an overlap, then we know that niche optimization is being used.
+        //
+        // We must also verify the discriminant actually overlaps with the variant
+        // data. Async state machines (and other enums) can have a discriminant at
+        // a large offset (e.g., at the end of the struct) while variant members
+        // start at offset 0, which is NOT niche optimization.
+        let discr_overlaps_variants = discr.offset_bytes * 8 == union_offset_bits;
+
         let member_at_zero = variant_part.variants.iter().any(|v| {
             v.members.iter().any(|m| {
                 let type_id = resolve_type_ref(m.type_ref.as_ref(), header_offset, global_type_map);
@@ -2036,7 +2041,7 @@ fn build_variant_part_members(
             header_offset,
         );
 
-        member_at_zero || nested_discr
+        discr_overlaps_variants && (member_at_zero || nested_discr)
     } else {
         false
     };

--- a/hansei/src/main.rs
+++ b/hansei/src/main.rs
@@ -30,6 +30,35 @@ enum Action {
     #[command(visible_alias = "dump")]
     SchedulerDump(Dump),
     Poll(Poll),
+    #[command(visible_alias = "trace")]
+    TaskTrace(TaskTrace),
+}
+
+#[derive(Args)]
+struct TaskTrace {
+    #[command(flatten)]
+    source: Source,
+
+    /// The address of the task in hexadecimal, e.g., 0x1234.
+    #[clap(long, short)]
+    addr: String,
+
+    /// The type of the task.
+    #[clap(long = "type", short)]
+    ty: String,
+
+    /// The CTF file to read.
+    #[clap(long, short)]
+    ctf: PathBuf,
+
+    /// Pausing a live process is potentially destructive.
+    /// Required if --pid is passed.
+    #[arg(long, short = 'w')]
+    destructive: bool,
+
+    /// Show the variables present at each await point.
+    #[clap(long, short)]
+    verbose: bool,
 }
 
 #[derive(Args)]
@@ -118,6 +147,7 @@ fn main() {
     let res = match args.action {
         Action::Poll(poll) => exec_poll(poll, Term::stdout()),
         Action::SchedulerDump(dump) => exec_dump(dump, &mut io::stdout().lock()),
+        Action::TaskTrace(dump) => exec_trace(dump, &mut io::stdout().lock()),
     };
     if let Err(e) = res {
         if let Some(io_err) = e.downcast_ref::<io::Error>()
@@ -294,4 +324,91 @@ fn maybe_style<T: Display>(
         Some(last) if now - last < HIGHLIGHT_DUR => console::style(value).green().bold(),
         _ => console::style(value),
     }
+}
+
+struct TraceContext<'ctf> {
+    pub proc: &'ctf Proc,
+    pub ctf: durin::read::CtfView<'ctf>,
+    pub mappings: proc::Mappings,
+}
+
+impl<'ctf> reify::ParseCtx<'ctf> for TraceContext<'ctf> {
+    fn proc(&self) -> &'ctf Proc {
+        self.proc
+    }
+
+    fn ctf(&self) -> &durin::read::CtfView<'ctf> {
+        &self.ctf
+    }
+
+    fn mappings(&self) -> &proc::Mappings {
+        &self.mappings
+    }
+}
+
+fn exec_trace(args: TaskTrace, out: &mut dyn io::Write) -> Result<()> {
+    let addr_str = args.addr.strip_prefix("0x").unwrap_or(args.addr.as_str());
+    let addr =
+        u64::from_str_radix(addr_str, 16).context("failed to parse address as hexadecimal")?;
+
+    let proc = args.source.open_proc(args.destructive)?;
+
+    let ctf_bytes =
+        fs::read(&args.ctf).with_context(|| format!("failed to read {}", args.ctf.display()))?;
+    let ctf = CtfReader::load(&ctf_bytes).context("failed to load CTF")?;
+    let view = ctf.view();
+
+    let ctx = TraceContext {
+        proc: &proc,
+        ctf: view,
+        mappings: proc.mappings()?,
+    };
+    let Some(task_ty) = ctx.ctf.find(&args.ty, durin::TypeKind::Struct) else {
+        anyhow::bail!("failed to find task CTF type");
+    };
+
+    let info = reify::TypeInfo::from_addr(&ctx, task_ty, addr)
+        .with_context(|| format!("failed to parse {:#x} as {}", addr, args.ty))?;
+
+    let Ok(stage) = info.member("core").and_then(|c| c.member("stage")) else {
+        anyhow::bail!("failed to find the future");
+    };
+
+    let (state, active) = stage.active_variant()?;
+    if state != "Running" {
+        anyhow::bail!("task is in {state} state, no trace available");
+    }
+
+    writeln!(out, "{}", stage.ty.name())?;
+    let mut active = active.to_owned();
+
+    while let Ok((await_point, var)) = active.as_ref().active_variant() {
+        writeln!(out, "    suspended at await point {}", await_point)?;
+
+        // TODO: this is hilariously overbroad.
+        if let Some(lock) = var.try_member("lock")? {
+            let addr: u64 = lock.parse(&ctx)?;
+            writeln!(out, "    blocked on mutex at {addr:#x}")?;
+        }
+
+        if args.verbose && !var.is_enum() {
+            writeln!(out, "    Arguments:")?;
+            for m in var.ty.members().filter(|m| m.name() != "__awaitee") {
+                let mm = var.member(m.name())?;
+                writeln!(out, "      {}: {}", m.name(), mm.display_with_depth(1))?;
+            }
+        }
+
+        writeln!(out, "waiting on: {}", var.ty.name())?;
+
+        // We have an explicit awaitee.
+        if let Some(aw) = var.try_member("__awaitee")? {
+            active = aw.to_owned();
+        } else {
+            // Move down to the next nested type.
+            active = var.to_owned();
+        }
+    }
+
+    Ok(())
 }

--- a/hansei/src/main.rs
+++ b/hansei/src/main.rs
@@ -91,6 +91,26 @@ struct Source {
     core: Option<PathBuf>,
 }
 
+impl Source {
+    fn open_proc(&self, destructive: bool) -> Result<Proc> {
+        match (self.pid, &self.core) {
+            (Some(pid), None) => {
+                anyhow::ensure!(
+                    destructive,
+                    "This command is potentially destructive when run against live \
+                processes. Pass the `-w` / `--destructive` flag to allow it."
+                );
+
+                Proc::grab_pid(pid).with_context(|| "failed to grab pid {pid}")
+            }
+            (None, Some(core)) => {
+                Proc::open_core(core).with_context(|| format!("failed to open {}", core.display()))
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
 fn main() {
     let args = Cli::parse();
 
@@ -111,21 +131,7 @@ fn main() {
 }
 
 fn exec_dump(args: Dump, out: &mut dyn io::Write) -> Result<()> {
-    let proc = match (args.source.pid, &args.source.core) {
-        (Some(pid), None) => {
-            anyhow::ensure!(
-                args.destructive,
-                "This command is potentially destructive when run against live \
-                processes. Pass the `-w` / `--destructive` flag to allow it."
-            );
-
-            Proc::grab_pid(pid).with_context(|| "failed to grab pid {pid}")?
-        }
-        (None, Some(core)) => {
-            Proc::open_core(core).with_context(|| format!("failed to open {}", core.display()))?
-        }
-        _ => unreachable!(),
-    };
+    let proc = args.source.open_proc(args.destructive)?;
     let main_lwp = proc.lwp_handle(1)?;
 
     let ctf_bytes =

--- a/hansei/src/main.rs
+++ b/hansei/src/main.rs
@@ -27,7 +27,8 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Action {
-    Dump(Dump),
+    #[command(visible_alias = "dump")]
+    SchedulerDump(Dump),
     Poll(Poll),
 }
 
@@ -116,7 +117,7 @@ fn main() {
 
     let res = match args.action {
         Action::Poll(poll) => exec_poll(poll, Term::stdout()),
-        Action::Dump(dump) => exec_dump(dump, &mut io::stdout().lock()),
+        Action::SchedulerDump(dump) => exec_dump(dump, &mut io::stdout().lock()),
     };
     if let Err(e) = res {
         if let Some(io_err) = e.downcast_ref::<io::Error>()

--- a/print-ctf/src/main.rs
+++ b/print-ctf/src/main.rs
@@ -55,14 +55,14 @@ fn exec(args: &Cli) -> Result<()> {
         };
 
         for ctf_ty in iter {
-            writeln!(out, "{}", format_type(&ctf_ty, depth, args.max_depth))?;
+            writeln!(out, "{}", format_type(&ctf_ty, depth, args.max_depth, 0))?;
         }
     }
 
     Ok(())
 }
 
-fn format_type(ty: &CtfType, depth: usize, max_depth: usize) -> String {
+fn format_type(ty: &CtfType, depth: usize, max_depth: usize, abs_offset: u64) -> String {
     if depth > max_depth {
         return String::new();
     }
@@ -114,7 +114,12 @@ fn format_type(ty: &CtfType, depth: usize, max_depth: usize) -> String {
                 if s.members().len() > 0 {
                     desc.push_str(", members:");
                 }
-                desc.push_str(&format_members(s.members(), depth + 1, max_depth));
+                desc.push_str(&format_members(
+                    s.members(),
+                    depth + 1,
+                    max_depth,
+                    abs_offset,
+                ));
             }
         }
         CtfType::Union(u) => {
@@ -124,7 +129,12 @@ fn format_type(ty: &CtfType, depth: usize, max_depth: usize) -> String {
                 if u.members().len() > 0 {
                     desc.push_str(", members:");
                 }
-                desc.push_str(&format_members(u.members(), depth + 1, max_depth));
+                desc.push_str(&format_members(
+                    u.members(),
+                    depth + 1,
+                    max_depth,
+                    abs_offset,
+                ));
             }
         }
         CtfType::Enum(e) => {
@@ -161,28 +171,36 @@ fn format_type(ty: &CtfType, depth: usize, max_depth: usize) -> String {
     desc
 }
 
-fn format_members(members: CtfMemberIter, depth: usize, max_depth: usize) -> String {
+fn format_members(
+    members: CtfMemberIter,
+    depth: usize,
+    max_depth: usize,
+    abs_offset: u64,
+) -> String {
     let mut desc = String::new();
     if depth > max_depth {
         return desc;
     }
 
     for member in members {
-        let member_desc = format_type(&member.ty(), depth, max_depth);
+        let mem_abs_off = abs_offset + member.offset();
+        let member_desc = format_type(&member.ty(), depth, max_depth, mem_abs_off);
         if member_desc.is_empty() {
             desc.push_str(&format!(
-                "\n{}{}, offset {}, {}",
+                "\n{}{}, offset {}, abs_offset: {}, {}",
                 "  ".repeat(depth),
                 member.name(),
                 member.offset(),
+                mem_abs_off,
                 ty_title(&member.ty())
             ));
         } else {
             desc.push_str(&format!(
-                "\n{}{}, offset {}, {}",
+                "\n{}{}, offset {}, abs_offset {}, {}",
                 "  ".repeat(depth),
                 member.name(),
                 member.offset(),
+                mem_abs_off,
                 member_desc,
             ));
         }

--- a/reify/src/lib.rs
+++ b/reify/src/lib.rs
@@ -609,6 +609,493 @@ impl fmt::Debug for TypeInfoRef<'_, '_> {
     }
 }
 
+impl fmt::Display for TypeInfoRef<'_, '_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_display_value(f, self, 0, 16)
+    }
+}
+
+impl fmt::Display for TypeInfo<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.as_ref(), f)
+    }
+}
+
+pub struct DisplayValue<'a, 'buf, 'ctf: 'buf> {
+    info: &'a TypeInfoRef<'buf, 'ctf>,
+    depth: usize,
+    max_depth: usize,
+}
+
+impl fmt::Display for DisplayValue<'_, '_, '_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_display_value(f, self.info, self.depth, self.max_depth)
+    }
+}
+
+impl<'buf, 'ctf: 'buf> TypeInfoRef<'buf, 'ctf> {
+    pub fn display(&self) -> DisplayValue<'_, 'buf, 'ctf> {
+        DisplayValue {
+            info: self,
+            depth: 0,
+            max_depth: 8,
+        }
+    }
+
+    pub fn display_with_depth(&self, max_depth: usize) -> DisplayValue<'_, 'buf, 'ctf> {
+        DisplayValue {
+            info: self,
+            depth: 0,
+            max_depth,
+        }
+    }
+}
+
+/// Wrapper that carries depth state for recursive formatting.
+struct DisplayRecurse<'buf, 'ctf: 'buf> {
+    info: TypeInfoRef<'buf, 'ctf>,
+    depth: usize,
+    max_depth: usize,
+}
+
+impl fmt::Display for DisplayRecurse<'_, '_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_display_value(f, &self.info, self.depth, self.max_depth)
+    }
+}
+
+fn write_display_value(
+    f: &mut fmt::Formatter<'_>,
+    info: &TypeInfoRef<'_, '_>,
+    depth: usize,
+    max_depth: usize,
+) -> fmt::Result {
+    let ty = info.ty;
+    let bytes = info.bytes;
+
+    if bytes.is_empty() && ty.size() == 0 {
+        return write!(f, "{}", ty.name());
+    }
+
+    if depth >= max_depth {
+        return write!(f, "...");
+    }
+
+    if (bytes.len() as u64) < ty.size() {
+        return write!(f, "<truncated>");
+    }
+
+    match ty {
+        CtfType::Integer(int_ty) => {
+            let enc = int_ty.encoding();
+            let flags = enc.flags;
+            let size = int_ty.size();
+
+            if flags.is_bool() {
+                return write!(f, "{}", bytes[0] != 0);
+            }
+
+            if flags.is_char() {
+                let ch = bytes[0];
+                return if ch.is_ascii_graphic() || ch == b' ' {
+                    write!(f, "'{}'", ch as char)
+                } else {
+                    write!(f, "'\\x{:02x}'", ch)
+                };
+            }
+
+            if flags.is_signed() {
+                match size {
+                    1 => write!(f, "{}", bytes[0] as i8),
+                    2 => write!(f, "{}", i16::from_le_bytes(bytes[..2].try_into().unwrap())),
+                    4 => write!(f, "{}", i32::from_le_bytes(bytes[..4].try_into().unwrap())),
+                    8 => write!(f, "{}", i64::from_le_bytes(bytes[..8].try_into().unwrap())),
+                    _ => write_hex_bytes(f, bytes),
+                }
+            } else {
+                match size {
+                    1 => write!(f, "{}", bytes[0]),
+                    2 => write!(f, "{}", u16::from_le_bytes(bytes[..2].try_into().unwrap())),
+                    4 => write!(f, "{}", u32::from_le_bytes(bytes[..4].try_into().unwrap())),
+                    8 => write!(f, "{}", u64::from_le_bytes(bytes[..8].try_into().unwrap())),
+                    _ => write_hex_bytes(f, bytes),
+                }
+            }
+        }
+
+        CtfType::Float(float_ty) => match float_ty.size() {
+            4 => write!(f, "{}", f32::from_le_bytes(bytes[..4].try_into().unwrap())),
+            8 => write!(f, "{}", f64::from_le_bytes(bytes[..8].try_into().unwrap())),
+            _ => write_hex_bytes(f, bytes),
+        },
+
+        CtfType::Pointer(_) => {
+            if bytes.len() < 8 {
+                return write!(f, "<truncated>");
+            }
+            let addr = u64::from_le_bytes(bytes[..8].try_into().unwrap());
+            if addr == 0 {
+                write!(f, "null")
+            } else {
+                write!(f, "0x{:x}", addr)
+            }
+        }
+
+        CtfType::Struct(_) => {
+            let name = ty.name();
+            let pretty = f.alternate();
+
+            // Rust enum: has __discr member
+            if ty.member("__discr").is_some() {
+                return write_rust_enum(f, info, name, pretty, depth, max_depth);
+            }
+
+            // Regular struct
+            write_struct_fields(f, info, name, pretty, depth, max_depth)
+        }
+
+        CtfType::Union(_) => {
+            // Rust enum tagged union pattern (e.g. __tagged unions with
+            // __discr + __variants).
+            if ty.member("__discr").is_some() && ty.member("__variants").is_some() {
+                let name = ty.name();
+                let enum_name = name.strip_suffix("::__tagged").unwrap_or(name);
+                let pretty = f.alternate();
+                return write_rust_enum(f, info, enum_name, pretty, depth, max_depth);
+            }
+
+            let name = ty.name();
+            if !name.is_empty() {
+                write!(f, "{} ", name)?;
+            }
+            write!(f, "{{ ")?;
+            write_hex_bytes(f, bytes)?;
+            write!(f, " }}")
+        }
+
+        CtfType::Enum(enum_ty) => {
+            let size = enum_ty.size();
+            let discrim = match size {
+                1 => bytes[0] as i64,
+                2 => i16::from_le_bytes(bytes[..2].try_into().unwrap()) as i64,
+                4 => i32::from_le_bytes(bytes[..4].try_into().unwrap()) as i64,
+                8 => i64::from_le_bytes(bytes[..8].try_into().unwrap()),
+                _ => return write_hex_bytes(f, bytes),
+            };
+
+            for e in enum_ty.enumerators() {
+                if e.value() == discrim {
+                    return write!(f, "{}", e.name());
+                }
+            }
+            write!(f, "{}", discrim)
+        }
+
+        CtfType::Array(arr_ty) => {
+            let elem_ty = arr_ty.element_type();
+            let elem_size = elem_ty.size() as usize;
+            let count = arr_ty.len() as usize;
+            let pretty = f.alternate();
+
+            write!(f, "[")?;
+            for i in 0..count {
+                let start = i * elem_size;
+                let end = start + elem_size;
+                if let Some(elem_bytes) = bytes.get(start..end) {
+                    if pretty {
+                        writeln!(f)?;
+                        write_indent(f, depth + 1)?;
+                    } else if i > 0 {
+                        write!(f, ", ")?;
+                    }
+
+                    let child = DisplayRecurse {
+                        info: TypeInfoRef {
+                            ty: elem_ty,
+                            addr: info.addr + start as u64,
+                            bytes: elem_bytes,
+                        },
+                        depth: depth + 1,
+                        max_depth,
+                    };
+                    if pretty {
+                        write!(f, "{:#},", child)?;
+                    } else {
+                        write!(f, "{}", child)?;
+                    }
+                } else {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "<truncated>")?;
+                    break;
+                }
+            }
+            if pretty && count > 0 {
+                writeln!(f)?;
+                write_indent(f, depth)?;
+            }
+            write!(f, "]")
+        }
+
+        CtfType::Typedef(_) | CtfType::Volatile(_) | CtfType::Const(_) | CtfType::Restrict(_) => {
+            if let Some(target) = ty.target() {
+                let child = DisplayRecurse {
+                    info: TypeInfoRef {
+                        ty: target,
+                        addr: info.addr,
+                        bytes,
+                    },
+                    depth: depth + 1,
+                    max_depth,
+                };
+                if f.alternate() {
+                    write!(f, "{:#}", child)
+                } else {
+                    write!(f, "{}", child)
+                }
+            } else {
+                let name = ty.name();
+                if !name.is_empty() {
+                    write!(f, "{} ", name)?;
+                }
+                write_hex_bytes(f, bytes)
+            }
+        }
+
+        _ => {
+            let name = ty.name();
+            if !name.is_empty() {
+                write!(f, "{} ", name)?;
+            }
+            write_hex_bytes(f, bytes)
+        }
+    }
+}
+
+fn write_struct_fields(
+    f: &mut fmt::Formatter<'_>,
+    info: &TypeInfoRef<'_, '_>,
+    name: &str,
+    pretty: bool,
+    depth: usize,
+    max_depth: usize,
+) -> fmt::Result {
+    let members: Vec<_> = info.ty.members().filter(|m| m.ty().size() > 0).collect();
+
+    if !name.is_empty() {
+        write!(f, "{}", name)?;
+    }
+    write!(f, " {{")?;
+
+    for (i, member) in members.iter().enumerate() {
+        let mem_ty = member.ty();
+        let start = member.offset() as usize;
+        let end = start + mem_ty.size() as usize;
+
+        if pretty {
+            writeln!(f)?;
+            write_indent(f, depth + 1)?;
+        } else if i > 0 {
+            write!(f, ",")?;
+        }
+        write!(f, " {}: ", member.name())?;
+
+        if let Some(mem_bytes) = info.bytes.get(start..end) {
+            let child = DisplayRecurse {
+                info: TypeInfoRef {
+                    ty: mem_ty,
+                    addr: info.addr + member.offset(),
+                    bytes: mem_bytes,
+                },
+                depth: depth + 1,
+                max_depth,
+            };
+            if pretty {
+                write!(f, "{:#}", child)?;
+            } else {
+                write!(f, "{}", child)?;
+            }
+        } else {
+            write!(f, "<truncated>")?;
+        }
+
+        if pretty {
+            write!(f, ",")?;
+        }
+    }
+
+    if pretty {
+        writeln!(f)?;
+        write_indent(f, depth)?;
+    } else {
+        write!(f, " ")?;
+    }
+    write!(f, "}}")
+}
+
+fn write_rust_enum(
+    f: &mut fmt::Formatter<'_>,
+    info: &TypeInfoRef<'_, '_>,
+    name: &str,
+    pretty: bool,
+    depth: usize,
+    max_depth: usize,
+) -> fmt::Result {
+    // Resolve variant without peeling so we preserve the full struct for
+    // display (active_variant calls .peel() which collapses wrapper structs
+    // and can land on inner tagged unions, losing structural info).
+    let Ok((discrim, discrim_ty)) = info.read_discriminant() else {
+        if !name.is_empty() {
+            write!(f, "{} ", name)?;
+        }
+        return write_hex_bytes(f, info.bytes);
+    };
+
+    let Some(variants_member) = info.ty.member("__variants") else {
+        if !name.is_empty() {
+            write!(f, "{} ", name)?;
+        }
+        return write_hex_bytes(f, info.bytes);
+    };
+    let variants = variants_member.ty();
+
+    let is_niche_optimized = variants.members().len() == 2 && discrim_ty.enumerators().len() == 1;
+
+    let enumerator = discrim_ty.enumerators().find(|e| e.value() == discrim);
+
+    write!(f, "{name} ")?;
+    let variant_name = match (enumerator, is_niche_optimized) {
+        (Some(e), _) => e.name(),
+        (None, true) => {
+            let Some(var) = variants
+                .members()
+                .find(|m| m.name() != discrim_ty.enumerators().nth(0).unwrap().name())
+            else {
+                if !name.is_empty() {
+                    write!(f, "{} ", name)?;
+                }
+                return Ok(()); // write_hex_bytes(f, info.bytes);
+            };
+            var.name()
+        }
+        (None, false) => {
+            if !name.is_empty() {
+                write!(f, "{} ", name)?;
+            }
+            return Ok(()); // write_hex_bytes(f, info.bytes);
+        }
+    };
+
+    let Some(selected_variant) = variants.member(variant_name) else {
+        if !name.is_empty() {
+            write!(f, "{} ", name)?;
+        }
+        return write_hex_bytes(f, info.bytes);
+    };
+    let variant_ty = selected_variant.ty();
+    let start = selected_variant.offset() as usize;
+    let end = start + variant_ty.size() as usize;
+    let Some(variant_bytes) = info.bytes.get(start..end) else {
+        if !name.is_empty() {
+            write!(f, "{} ", name)?;
+        }
+        return write_hex_bytes(f, info.bytes);
+    };
+    let variant_addr = info.addr + selected_variant.offset();
+    // NOTE: no .peel() — we keep the variant struct intact for display.
+    let variant_info = TypeInfoRef {
+        ty: variant_ty,
+        addr: variant_addr,
+        bytes: variant_bytes,
+    }
+    .peel();
+
+    if !name.is_empty() {
+        write!(f, "{}::", name)?;
+    }
+    write!(f, "{}", variant_name)?;
+
+    // Zero-sized variant (unit variant)
+    if variant_ty.size() == 0 {
+        return Ok(());
+    }
+
+    let members: Vec<_> = variant_info
+        .ty
+        .members()
+        .filter(|m| m.ty().size() > 0)
+        .collect();
+
+    if members.is_empty() {
+        return Ok(());
+    }
+
+    write!(f, " {{")?;
+    for (i, member) in members.iter().enumerate() {
+        let mem_ty = member.ty();
+        let mem_start = member.offset() as usize;
+        let mem_end = mem_start + mem_ty.size() as usize;
+
+        if pretty {
+            writeln!(f)?;
+            write_indent(f, depth + 1)?;
+        } else if i > 0 {
+            write!(f, ",")?;
+        }
+        write!(f, " {}: ", member.name())?;
+
+        if let Some(mem_bytes) = variant_info.bytes.get(mem_start..mem_end) {
+            let child = DisplayRecurse {
+                info: TypeInfoRef {
+                    ty: mem_ty,
+                    addr: variant_info.addr + member.offset(),
+                    bytes: mem_bytes,
+                },
+                depth: depth + 1,
+                max_depth,
+            };
+            if pretty {
+                write!(f, "{:#}", child)?;
+            } else {
+                write!(f, "{}", child)?;
+            }
+        } else {
+            write!(f, "<truncated>")?;
+        }
+
+        if pretty {
+            write!(f, ",")?;
+        }
+    }
+
+    if pretty {
+        writeln!(f)?;
+        write_indent(f, depth)?;
+    } else {
+        write!(f, " ")?;
+    }
+    write!(f, "}}")
+}
+
+fn write_indent(f: &mut fmt::Formatter<'_>, depth: usize) -> fmt::Result {
+    for _ in 0..depth {
+        write!(f, "    ")?;
+    }
+    Ok(())
+}
+
+fn write_hex_bytes(f: &mut fmt::Formatter<'_>, bytes: &[u8]) -> fmt::Result {
+    write!(f, "[")?;
+    for (i, b) in bytes.iter().enumerate() {
+        if i > 0 {
+            write!(f, ", ")?;
+        }
+        write!(f, "0x{:02x}", b)?;
+    }
+    write!(f, "]")
+}
+
 impl<'buf, 'ctf: 'buf> From<&'buf TypeInfo<'ctf>> for TypeInfoRef<'buf, 'ctf> {
     #[inline]
     fn from(TypeInfo { ty, addr, buf }: &'buf TypeInfo<'ctf>) -> Self {

--- a/reify/src/lib.rs
+++ b/reify/src/lib.rs
@@ -583,11 +583,12 @@ impl<'buf, 'ctf: 'buf> TypeInfoRef<'buf, 'ctf> {
                 format!("{} ({:?})", self.ty.name(), self.ty.id()),
             ));
         };
+        let offset = discriminant.offset() as usize;
         let discrim_value = match discr_enum.size() {
-            1 => self.bytes[0] as i64,
-            2 => i16::from_le_bytes(*self.bytes.first_chunk::<2>().unwrap()) as i64,
-            4 => i32::from_le_bytes(*self.bytes.first_chunk::<4>().unwrap()) as i64,
-            8 => i64::from_le_bytes(*self.bytes.first_chunk::<8>().unwrap()),
+            1 => self.bytes[offset] as i64,
+            2 => i16::from_le_bytes(*self.bytes[offset..].first_chunk::<2>().unwrap()) as i64,
+            4 => i32::from_le_bytes(*self.bytes[offset..].first_chunk::<4>().unwrap()) as i64,
+            8 => i64::from_le_bytes(*self.bytes[offset..].first_chunk::<8>().unwrap()),
             _ => unreachable!(), // validated during parsing
         };
         Ok((discrim_value, discr_ty))

--- a/reify/src/lib.rs
+++ b/reify/src/lib.rs
@@ -347,6 +347,10 @@ impl<'buf, 'ctf: 'buf> TypeInfoRef<'buf, 'ctf> {
         }
     }
 
+    pub fn is_enum(&self) -> bool {
+        self.member("__discr").ok().is_some()
+    }
+
     pub fn try_select_variant(&self, name: &str) -> Result<Option<TypeInfoRef<'buf, 'ctf>>> {
         let (discrim_value, discrim_ty) = self.read_discriminant()?;
 


### PR DESCRIPTION
Add a new `task-trace` subcommand that shows an async-trace, shamelessly stealing the format used in [Cliff's async debugger article](https://cliffle.com/blog/lildb).

The mechanics of walking the async "stack" are actually pretty simple:

1. The user provides the address and type of the future. The former can be retrieved from `scheduler-dump`, the latter must be inferred from source code and DWARF. This step clearly needs improvement.
2. Find the `Cell`'s `core.stage` member.
3. From there, loop while there is an active variant for the stage. If there's an `__awaitee` member we jump to that, otherwise we use the active variant as the next type.


There's often a number variables present at a suspend point, include a `--verbose` flag to print a few nested levels of them with very basic formatting.