### PR TITLE
print-ctf: Add '--quiet' flag for simpler printing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,5 +47,5 @@ tokio = "1.47.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-[profile.release]
+[profile.release.package.test-programs]
 debug = true

--- a/hansei/src/main.rs
+++ b/hansei/src/main.rs
@@ -379,6 +379,9 @@ fn exec_trace(args: TaskTrace, out: &mut dyn io::Write) -> Result<()> {
         anyhow::bail!("task is in {state} state, no trace available");
     }
 
+    let task_id: u64 = info.member("core")?.member("task_id")?.parse(&ctx)?;
+
+    writeln!(out, "Task {task_id}:")?;
     writeln!(out, "{}", stage.ty.name())?;
     let mut active = active.to_owned();
 

--- a/print-ctf/src/main.rs
+++ b/print-ctf/src/main.rs
@@ -19,6 +19,10 @@ struct Cli {
     /// top-level type without expanding members.
     #[clap(short = 'd', long, default_value_t = 3)]
     max_depth: usize,
+
+    /// Only print type and member names
+    #[clap(long, short)]
+    quiet: bool,
 }
 
 fn main() {
@@ -55,32 +59,46 @@ fn exec(args: &Cli) -> Result<()> {
         };
 
         for ctf_ty in iter {
-            writeln!(out, "{}", format_type(&ctf_ty, depth, args.max_depth, 0))?;
+            writeln!(
+                out,
+                "{}",
+                format_type(&ctf_ty, depth, args.max_depth, 0, args.quiet)
+            )?;
         }
     }
 
     Ok(())
 }
 
-fn format_type(ty: &CtfType, depth: usize, max_depth: usize, abs_offset: u64) -> String {
+fn format_type(
+    ty: &CtfType,
+    depth: usize,
+    max_depth: usize,
+    abs_offset: u64,
+    quiet: bool,
+) -> String {
     if depth > max_depth {
         return String::new();
     }
 
-    let mut desc = ty_title(ty);
+    let mut desc = ty_title(ty, quiet);
 
     match ty {
         CtfType::Unknown(_u) => {
             // No further formatting.
         }
         CtfType::Integer(i) => {
-            desc.push_str(&format!(", size {}, encoding {:?}", i.size(), i.encoding()));
+            if !quiet {
+                desc.push_str(&format!(", size {}, encoding {:?}", i.size(), i.encoding()));
+            }
         }
         CtfType::Float(f) => {
-            desc.push_str(&format!(", size {}, encoding {:?}", f.size(), f.encoding()));
+            if !quiet {
+                desc.push_str(&format!(", size {}, encoding {:?}", f.size(), f.encoding()));
+            }
         }
         CtfType::Pointer(p) => {
-            desc.push_str(&format!(", target {}", ty_title(&p.target())));
+            desc.push_str(&format!(", target {}", ty_title(&p.target(), quiet)));
         }
         CtfType::Array(a) => {
             desc.push_str(&format!(
@@ -92,7 +110,7 @@ fn format_type(ty: &CtfType, depth: usize, max_depth: usize, abs_offset: u64) ->
         CtfType::Function(f) => {
             desc.push_str(&format!(
                 ", return type {}, is_varargs: {}",
-                ty_title(&f.return_type()),
+                ty_title(&f.return_type(), quiet),
                 f.is_varargs(),
             ));
             if f.arg_count() > 0 {
@@ -109,7 +127,9 @@ fn format_type(ty: &CtfType, depth: usize, max_depth: usize, abs_offset: u64) ->
             todo!()
         }
         CtfType::Struct(s) => {
-            desc.push_str(&format!(", size: {}", s.size()));
+            if !quiet {
+                desc.push_str(&format!(", size: {}", s.size()));
+            }
             if depth < max_depth {
                 if s.members().len() > 0 {
                     desc.push_str(", members:");
@@ -119,11 +139,14 @@ fn format_type(ty: &CtfType, depth: usize, max_depth: usize, abs_offset: u64) ->
                     depth + 1,
                     max_depth,
                     abs_offset,
+                    quiet,
                 ));
             }
         }
         CtfType::Union(u) => {
-            desc.push_str(&format!(", size: {}", u.size()));
+            if !quiet {
+                desc.push_str(&format!(", size: {}", u.size()));
+            }
 
             if depth < max_depth {
                 if u.members().len() > 0 {
@@ -134,6 +157,7 @@ fn format_type(ty: &CtfType, depth: usize, max_depth: usize, abs_offset: u64) ->
                     depth + 1,
                     max_depth,
                     abs_offset,
+                    quiet,
                 ));
             }
         }
@@ -155,16 +179,16 @@ fn format_type(ty: &CtfType, depth: usize, max_depth: usize, abs_offset: u64) ->
             // No further formatting.
         }
         CtfType::Typedef(t) => {
-            desc.push_str(&format!(", target {}", ty_title(&t.target())));
+            desc.push_str(&format!(", target {}", ty_title(&t.target(), quiet)));
         }
         CtfType::Volatile(v) => {
-            desc.push_str(&format!(", target {}", ty_title(&v.target())));
+            desc.push_str(&format!(", target {}", ty_title(&v.target(), quiet)));
         }
         CtfType::Const(c) => {
-            desc.push_str(&format!(", target {}", ty_title(&c.target())));
+            desc.push_str(&format!(", target {}", ty_title(&c.target(), quiet)));
         }
         CtfType::Restrict(r) => {
-            desc.push_str(&format!(", target {}", ty_title(&r.target())));
+            desc.push_str(&format!(", target {}", ty_title(&r.target(), quiet)));
         }
     }
 
@@ -176,6 +200,7 @@ fn format_members(
     depth: usize,
     max_depth: usize,
     abs_offset: u64,
+    quiet: bool,
 ) -> String {
     let mut desc = String::new();
     if depth > max_depth {
@@ -184,31 +209,53 @@ fn format_members(
 
     for member in members {
         let mem_abs_off = abs_offset + member.offset();
-        let member_desc = format_type(&member.ty(), depth, max_depth, mem_abs_off);
+        let member_desc = format_type(&member.ty(), depth, max_depth, mem_abs_off, quiet);
         if member_desc.is_empty() {
-            desc.push_str(&format!(
-                "\n{}{}, offset {}, abs_offset: {}, {}",
-                "  ".repeat(depth),
-                member.name(),
-                member.offset(),
-                mem_abs_off,
-                ty_title(&member.ty())
-            ));
+            if quiet {
+                desc.push_str(&format!(
+                    "\n{}{}, {}",
+                    "  ".repeat(depth),
+                    member.name(),
+                    ty_title(&member.ty(), quiet)
+                ));
+            } else {
+                desc.push_str(&format!(
+                    "\n{}{}, offset {}, abs_offset: {}, {}",
+                    "  ".repeat(depth),
+                    member.name(),
+                    member.offset(),
+                    mem_abs_off,
+                    ty_title(&member.ty(), quiet)
+                ));
+            }
         } else {
-            desc.push_str(&format!(
-                "\n{}{}, offset {}, abs_offset {}, {}",
-                "  ".repeat(depth),
-                member.name(),
-                member.offset(),
-                mem_abs_off,
-                member_desc,
-            ));
+            if quiet {
+                desc.push_str(&format!(
+                    "\n{}{}, {}",
+                    "  ".repeat(depth),
+                    member.name(),
+                    member_desc,
+                ));
+            } else {
+                desc.push_str(&format!(
+                    "\n{}{}, offset {}, abs_offset {}, {}",
+                    "  ".repeat(depth),
+                    member.name(),
+                    member.offset(),
+                    mem_abs_off,
+                    member_desc,
+                ));
+            }
         }
     }
 
     desc
 }
 
-fn ty_title(ty: &CtfType) -> String {
-    format!("<{}> {} {}", ty.id().get(), ty.kind(), ty.name())
+fn ty_title(ty: &CtfType, quiet: bool) -> String {
+    if quiet {
+        format!("{} {}", ty.kind(), ty.name())
+    } else {
+        format!("<{}> {} {}", ty.id().get(), ty.kind(), ty.name())
+    }
 }

--- a/test-programs/Cargo.toml
+++ b/test-programs/Cargo.toml
@@ -8,8 +8,5 @@ futures = "0.3.32"
 oxide-tokio-rt = "0.1.2"
 tokio = { version = "1.49.0", features = [ "full", "test-util" ] }
 
-[profile.release]
-debug = true
-
 [[bin]]
 name = "futurelock"


### PR DESCRIPTION
The default format for `print-ctf` is quite noisy, with the CTF type ID, size, offset, and absolute offset of each field.
    
Add a `--quiet` flag to display just the name and type of each field and cut down on the visual noise.

Also print task ID with task trace in `hansei` and fix the debug profile settings for `test-programs`.